### PR TITLE
Upgrade the libavif version, supports the AVIF encoding feature

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "SDWebImage/SDWebImage" ~> 5.0
-github "SDWebImage/libavif-Xcode"
+github "SDWebImage/libavif-Xcode" >= 0.1.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "SDWebImage/SDWebImage" "5.0.1"
-github "SDWebImage/libaom-Xcode" "1.0.0"
-github "SDWebImage/libavif-Xcode" "0.1.0"
+github "SDWebImage/SDWebImage" "5.0.2"
+github "SDWebImage/libaom-Xcode" "1.0.1"
+github "SDWebImage/libavif-Xcode" "0.1.3"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - libaom (1.0.0)
-  - libavif (0.1.0):
-    - libaom
-  - SDWebImage (5.0.1):
-    - SDWebImage/Core (= 5.0.1)
-  - SDWebImage/Core (5.0.1)
+  - libaom (1.0.1)
+  - libavif (0.1.3):
+    - libaom (>= 1.0.1)
+  - SDWebImage (5.0.2):
+    - SDWebImage/Core (= 5.0.2)
+  - SDWebImage/Core (5.0.2)
   - SDWebImageAVIFCoder (0.1.0):
-    - libavif
+    - libavif (>= 0.1.3)
     - SDWebImage (~> 5.0)
 
 DEPENDENCIES:
@@ -23,10 +23,10 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  libaom: d84044f314a1eac538c20965ac7df6fe6cee6ac6
-  libavif: 1513b919d6d7beb8fd8cc2e4a71538609409895b
-  SDWebImage: 27dd2c9ea07a2252f94557c9fbb6105ee94b74c9
-  SDWebImageAVIFCoder: 66893c86fbaa82c54556186fe9f62a601b27dfd0
+  libaom: 1e48c68559b8d6191c1a9f266e0bee83b2dd21fd
+  libavif: b6de15e6a91a347806b2fcc1fccd471c821f6d6a
+  SDWebImage: 6764b5fa0f73c203728052955dbefa2bf1f33282
+  SDWebImageAVIFCoder: 1e80598038f37e20a83a7a790cb192e0b362a557
 
 PODFILE CHECKSUM: cb60778bff8fb5ce4fbc8792f6079317b7a897be
 

--- a/Example/SDWebImageAVIFCoder/SDViewController.m
+++ b/Example/SDWebImageAVIFCoder/SDViewController.m
@@ -35,7 +35,13 @@
     
     [imageView1 sd_setImageWithURL:AVIFURL placeholderImage:nil options:0 completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
-            NSLog(@"Single HEIC load success");
+            NSLog(@"Static AVIF load success");
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                NSData *avifData = [SDImageAVIFCoder.sharedCoder encodedDataWithImage:image format:SDImageFormatAVIF options:nil];
+                if (avifData) {
+                    NSLog(@"Static AVIF encode success");
+                }
+            });
         }
     }];
     [imageView2 sd_setImageWithURL:HDRAVIFURL completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {

--- a/Example/SDWebImageAVIFCoder_Example macOS/ViewController.m
+++ b/Example/SDWebImageAVIFCoder_Example macOS/ViewController.m
@@ -34,6 +34,12 @@
     [imageView1 sd_setImageWithURL:AVIFURL completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
         if (image) {
             NSLog(@"Static AVIF load success");
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                NSData *avifData = [SDImageAVIFCoder.sharedCoder encodedDataWithImage:image format:SDImageFormatAVIF options:nil];
+                if (avifData) {
+                    NSLog(@"Static AVIF encode success");
+                }
+            });
         }
     }];
     [imageView2 sd_setImageWithURL:HDRAVIFURL completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This is a [SDWebImage](https://github.com/rs/SDWebImage) coder plugin to add [AV
 
 This AVIF coder plugin currently support AVIF still image **decoding**. Including alpha channel, as well as 10bit/12bit HDR images.
 
-The AVIF encoding is not currently support, because the software-based encoding speed is really slow. Need to wait for better enc implementation.
+The AVIF encoding is also supported now. Which always encode as 8-bit depth images.
 
-Note: AVIF image spec is still in evolve. And the current AVIF codec is a simple implementation.
+Note: AVIF image spec is still in evolve. And the current upstream AVIF codec is a simple implementation. The encoding time may be long for large images.
 
 Since AVIF is AV1-based inside HEIF image container. In the future, this repo may moved to existing HEIF coder plugin [SDWebImageHEIFCoder](https://github.com/SDWebImage/SDWebImageHEIFCoder) instead. 
 
@@ -35,17 +35,7 @@ it, simply add the following line to your Podfile:
 pod 'SDWebImageAVIFCoder'
 ```
 
-Note: Current `libaom` dependency via CocoaPods, use the pre-built static library for each architecutre.
-
-The reason of this it's that we want to use SIMD/SSE/AVX2 CPU instruction optimization for each platforms. However libaom does not using dynamic CPU detection for Apple's platforms. We need the upstream to support it.
-
-At the same time, CocoaPods does not allow you to write a framework contains so much of architecture detection (for example, iPhone Simulator is x86_x64, however, iPhone is ARM, they should use different assembly files). So we use the pre-built one instead. 
-
-If you're using `use_frameworks!` in Podfile, you can check it with static framework instead.
-
-```
-pod 'SDWebImageAVIFCoder', :modular_headers => true
-```
+Note: From version 0.2.0, the dependency libavif and libaom use the portable C implementation to works on Apple platforms. If you need the pre-built library with SIMD/AVX and assembly optimization, try the 0.1.0 version. 
 
 #### Carthage
 
@@ -54,10 +44,6 @@ SDWebImageAVIFCoder is available through [Carthage](https://github.com/Carthage/
 ```
 github "SDWebImage/SDWebImageAVIFCoder"
 ```
-
-Note: Carthage dependency of `libaom` using the C implementation codec, instead of original SIMD/SSE/AVX accelerated and assembly implementation, because it need extra dependency (CMake && NASM build tool).
-
-The C implementation make it possible to cross-platform in tvOS/watchOS as well. But if you're care about performance, try CocoaPods instead.
 
 ## Usage
 

--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -30,9 +30,11 @@ Which is built based on the open-sourced libavif codec.
   s.module_map = 'SDWebImageAVIFCoder/Module/SDWebImageAVIFCoder.modulemap'
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
 
   s.source_files = 'SDWebImageAVIFCoder/Classes/**/*', 'SDWebImageAVIFCoder/Module/SDWebImageAVIFCoder.h'
   
   s.dependency 'SDWebImage', '~> 5.0'
-  s.dependency 'libavif'
+  s.dependency 'libavif', '>= 0.1.3'
 end

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -164,7 +164,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     return imageRef;
 }
 
-// The AVIF encoding seems too slow at the current time
+// The AVIF encoding seems slow at the current time, but at least works
 - (BOOL)canEncodeToFormat:(SDImageFormat)format {
     return format == SDImageFormatAVIF;
 }

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -50,6 +50,30 @@ static void ConvertAvifImagePlanarToRGB(avifImage * avif, uint8_t * outPixels) {
     }
 }
 
+static void FillRGBABufferWithAVIFImage(vImage_Buffer *red, vImage_Buffer *green, vImage_Buffer *blue, vImage_Buffer *alpha, avifImage *img) {
+    red->width = img->width;
+    red->height = img->height;
+    red->data = img->rgbPlanes[AVIF_CHAN_R];
+    red->rowBytes = img->rgbRowBytes[AVIF_CHAN_R];
+    
+    green->width = img->width;
+    green->height = img->height;
+    green->data = img->rgbPlanes[AVIF_CHAN_G];
+    green->rowBytes = img->rgbRowBytes[AVIF_CHAN_G];
+    
+    blue->width = img->width;
+    blue->height = img->height;
+    blue->data = img->rgbPlanes[AVIF_CHAN_B];
+    blue->rowBytes = img->rgbRowBytes[AVIF_CHAN_B];
+    
+    if (img->alphaPlane != NULL) {
+        alpha->width = img->width;
+        alpha->height = img->height;
+        alpha->data = img->alphaPlane;
+        alpha->rowBytes = img->alphaRowBytes;
+    }
+}
+
 static void FreeImageData(void *info, const void *data, size_t size) {
     free((void *)data);
 }
@@ -142,11 +166,124 @@ static void FreeImageData(void *info, const void *data, size_t size) {
 
 // The AVIF encoding seems too slow at the current time
 - (BOOL)canEncodeToFormat:(SDImageFormat)format {
-    return NO;
+    return format == SDImageFormatAVIF;
 }
 
-- (nullable NSData *)encodedDataWithImage:(nullable UIImage *)image format:(SDImageFormat)format options:(nullable SDImageCoderOptions *)options { 
-    return nil;
+- (nullable NSData *)encodedDataWithImage:(nullable UIImage *)image format:(SDImageFormat)format options:(nullable SDImageCoderOptions *)options {
+    CGImageRef imageRef = image.CGImage;
+    if (!imageRef) {
+        return nil;
+    }
+    
+    size_t width = CGImageGetWidth(imageRef);
+    size_t height = CGImageGetHeight(imageRef);
+    size_t bitsPerPixel = CGImageGetBitsPerPixel(imageRef);
+    size_t bitsPerComponent = CGImageGetBitsPerComponent(imageRef);
+    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
+    CGImageAlphaInfo alphaInfo = bitmapInfo & kCGBitmapAlphaInfoMask;
+    CGBitmapInfo byteOrderInfo = bitmapInfo & kCGBitmapByteOrderMask;
+    BOOL hasAlpha = !(alphaInfo == kCGImageAlphaNone ||
+                      alphaInfo == kCGImageAlphaNoneSkipFirst ||
+                      alphaInfo == kCGImageAlphaNoneSkipLast);
+    BOOL byteOrderNormal = NO;
+    switch (byteOrderInfo) {
+        case kCGBitmapByteOrderDefault: {
+            byteOrderNormal = YES;
+        } break;
+        case kCGBitmapByteOrder32Little: {
+        } break;
+        case kCGBitmapByteOrder32Big: {
+            byteOrderNormal = YES;
+        } break;
+        default: break;
+    }
+    
+    vImageConverterRef convertor = NULL;
+    vImage_Error v_error = kvImageNoError;
+    
+    vImage_CGImageFormat srcFormat = {
+        .bitsPerComponent = (uint32_t)bitsPerComponent,
+        .bitsPerPixel = (uint32_t)bitsPerPixel,
+        .colorSpace = CGImageGetColorSpace(imageRef),
+        .bitmapInfo = bitmapInfo
+    };
+    vImage_CGImageFormat destFormat = {
+        .bitsPerComponent = 8,
+        .bitsPerPixel = hasAlpha ? 32 : 24,
+        .colorSpace = [SDImageCoderHelper colorSpaceGetDeviceRGB],
+        .bitmapInfo = hasAlpha ? kCGImageAlphaFirst | kCGBitmapByteOrderDefault : kCGImageAlphaNone | kCGBitmapByteOrderDefault // RGB888/ARGB8888 (Non-premultiplied to works for libbpg)
+    };
+    
+    convertor = vImageConverter_CreateWithCGImageFormat(&srcFormat, &destFormat, NULL, kvImageNoFlags, &v_error);
+    if (v_error != kvImageNoError) {
+        return nil;
+    }
+    
+    vImage_Buffer src;
+    v_error = vImageBuffer_InitWithCGImage(&src, &srcFormat, NULL, imageRef, kvImageNoFlags);
+    if (v_error != kvImageNoError) {
+        return nil;
+    }
+    vImage_Buffer dest;
+    vImageBuffer_Init(&dest, height, width, hasAlpha ? 32 : 24, kvImageNoFlags);
+    if (!dest.data) {
+        free(src.data);
+        return nil;
+    }
+    
+    // Convert input color mode to RGB888/ARGB8888
+    v_error = vImageConvert_AnyToAny(convertor, &src, &dest, NULL, kvImageNoFlags);
+    free(src.data);
+    vImageConverter_Release(convertor);
+    if (v_error != kvImageNoError) {
+        free(dest.data);
+        return nil;
+    }
+    
+    avifPixelFormat avifFormat = AVIF_PIXEL_FORMAT_YUV444;
+    enum avifPlanesFlags planesFlags = hasAlpha ? AVIF_PLANES_RGB | AVIF_PLANES_A : AVIF_PLANES_RGB;
+    
+    avifImage *avif = avifImageCreate((int)width, (int)height, 8, avifFormat);
+    if (!avif) {
+        free(dest.data);
+        return nil;
+    }
+    avifImageAllocatePlanes(avif, planesFlags);
+    
+    NSData *iccProfile = (__bridge_transfer NSData *)CGColorSpaceCopyICCProfile([SDImageCoderHelper colorSpaceGetDeviceRGB]);
+    
+    avifImageSetProfileICC(avif, (uint8_t *)iccProfile.bytes, iccProfile.length);
+    
+    vImage_Buffer red, green, blue, alpha;
+    FillRGBABufferWithAVIFImage(&red, &green, &blue, &alpha, avif);
+    
+    if (hasAlpha) {
+        v_error = vImageConvert_ARGB8888toPlanar8(&dest, &alpha, &red, &green, &blue, kvImageNoFlags);
+    } else {
+        v_error = vImageConvert_RGB888toPlanar8(&dest, &red, &green, &blue, kvImageNoFlags);
+    }
+    free(dest.data);
+    if (v_error != kvImageNoError) {
+        return nil;
+    }
+    
+    double compressionQuality = 1;
+    if (options[SDImageCoderEncodeCompressionQuality]) {
+        compressionQuality = [options[SDImageCoderEncodeCompressionQuality] doubleValue];
+    }
+    int rescaledQuality = 63 - (int)((compressionQuality) * 63.0f);
+    
+    avifRawData raw = AVIF_RAW_DATA_EMPTY;
+    avifResult result = avifImageWrite(avif, &raw, 2, rescaledQuality);
+    
+    if (result != AVIF_RESULT_OK) {
+        return nil;
+    }
+    
+    NSData *imageData = [NSData dataWithBytes:raw.data length:raw.size];
+    free(raw.data);
+    
+    return imageData;
 }
 
 


### PR DESCRIPTION
Seems the [libavif](https://github.com/joedrago/avif) upstream version, supports a better AVIF encoding solution. Which fix some serious bugs (the encoded image brand is not `ftpyavif`.

So maybe it's time to upgrade. The encoding speed, is slow (even compared to bpg format), but however, it's because of the upstream naive implementation, which can be fixed in the future, or with another [dav1d](https://github.com/videolan/dav1d) codec.


PS: Tthis time I also upgrade the libaom with C implementation code, without the assembly code as well. Make it portable for all Apple platforms, like the Carthage one.