### PR TITLE
Fix the compatible for libavif 1.0.4 version

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "SDWebImage/SDWebImage" "5.0.2"
+github "SDWebImage/SDWebImage" "5.1.0"
 github "SDWebImage/libaom-Xcode" "1.0.1"
-github "SDWebImage/libavif-Xcode" "0.1.3"
+github "SDWebImage/libavif-Xcode" "0.1.4"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - libaom (1.0.1)
-  - libavif (0.1.3):
+  - libavif (0.1.4):
     - libaom (>= 1.0.1)
-  - SDWebImage (5.0.2):
-    - SDWebImage/Core (= 5.0.2)
-  - SDWebImage/Core (5.0.2)
-  - SDWebImageAVIFCoder (0.1.0):
-    - libavif (>= 0.1.3)
+  - SDWebImage (5.1.0):
+    - SDWebImage/Core (= 5.1.0)
+  - SDWebImage/Core (5.1.0)
+  - SDWebImageAVIFCoder (0.2.0):
+    - libavif (~> 0.1.4)
     - SDWebImage (~> 5.0)
 
 DEPENDENCIES:
@@ -24,10 +24,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   libaom: 1e48c68559b8d6191c1a9f266e0bee83b2dd21fd
-  libavif: b6de15e6a91a347806b2fcc1fccd471c821f6d6a
-  SDWebImage: 6764b5fa0f73c203728052955dbefa2bf1f33282
-  SDWebImageAVIFCoder: 1e80598038f37e20a83a7a790cb192e0b362a557
+  libavif: 4f94ed672d45d6651ee0f784f5faf11b95449716
+  SDWebImage: fb387001955223213dde14bc08c8b73f371f8d8f
+  SDWebImageAVIFCoder: ec08ff2cf12552223b51b7253c8201d264ecbbac
 
 PODFILE CHECKSUM: cb60778bff8fb5ce4fbc8792f6079317b7a897be
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.5

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## What's for
 
-This is a [SDWebImage](https://github.com/rs/SDWebImage) coder plugin to add [AV1 Image File Format (AVIF)](https://aomediacodec.github.io/av1-avif/) support. Which is built based on the open-sourced [libavif](https://github.com/joedrago/avif) codec.
+This is a [SDWebImage](https://github.com/rs/SDWebImage) coder plugin to add [AV1 Image File Format (AVIF)](https://aomediacodec.github.io/av1-avif/) support. Which is built based on the open-sourced [libavif](https://github.com/AOMediaCodec/libavif) codec.
 
 This AVIF coder plugin currently support AVIF still image **decoding**. Including alpha channel, as well as 10bit/12bit HDR images.
 
@@ -92,7 +92,7 @@ SDWebImageAVIFCoder is available under the MIT license. See the LICENSE file for
 
 ## Thanks
 
-+ [libavif](https://github.com/joedrago/avif)
++ [libavif](https://github.com/AOMediaCodec/libavif)
 + [aom](https://aomedia.googlesource.com/aom/)
 + [AVIFQuickLook](https://github.com/dreampiggy/AVIFQuickLook)
 + [avif.js](https://github.com/Kagami/avif.js)

--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -36,5 +36,5 @@ Which is built based on the open-sourced libavif codec.
   s.source_files = 'SDWebImageAVIFCoder/Classes/**/*', 'SDWebImageAVIFCoder/Module/SDWebImageAVIFCoder.h'
   
   s.dependency 'SDWebImage', '~> 5.0'
-  s.dependency 'libavif', '>= 0.1.3'
+  s.dependency 'libavif', '~> 0.1.4'
 end

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -134,6 +134,9 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         return nil;
     }
     
+    // use RGB instead of YUV
+    avifImageYUVToRGB(avif);
+    
     int width = avif->width;
     int height = avif->height;
     BOOL hasAlpha = avif->alphaPlane != NULL;


### PR DESCRIPTION
Which use YUV as default and no RGB plane is decoded, unless you call.

The libavif repo move from personal repo to the AOM organization.

The libavif 1.0.4 -> 2.0 have API breaks. So we must update the podspec to use `~>` for better management. 2.0 compatible will be available soon.