### PR TITLE
Upgrade libavif to 0.3.0, support dav1d instead aom for decoding, which is faster

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "SDWebImage/SDWebImage" ~> 5.0
-github "SDWebImage/libavif-Xcode" ~> 0.2.0
+github "SDWebImage/libavif-Xcode" ~> 0.3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "SDWebImage/SDWebImage" "5.1.0"
+github "SDWebImage/SDWebImage" "5.2.2"
 github "SDWebImage/libaom-Xcode" "1.0.1"
-github "SDWebImage/libavif-Xcode" "0.2.0"
+github "SDWebImage/libavif-Xcode" "0.3.0"

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,6 +3,7 @@
 target 'SDWebImageAVIFCoder_Example' do
   platform :ios, '8.0'
   pod 'SDWebImageAVIFCoder', :path => '../'
+  pod 'libavif', :subspecs => ['libaom', 'libdav1d']
 
   target 'SDWebImageAVIFCoder_Tests' do
     inherit! :search_paths
@@ -14,4 +15,5 @@ end
 target 'SDWebImageAVIFCoder_Example macOS' do
   platform :osx, '10.10'
   pod 'SDWebImageAVIFCoder', :path => '../'
+  pod 'libavif', :subspecs => ['libaom', 'libdav1d']
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,21 +1,30 @@
 PODS:
   - libaom (1.0.1)
-  - libavif (0.2.0):
+  - libavif (0.3.0):
+    - libavif/libaom (= 0.3.0)
+  - libavif/libaom (0.3.0):
     - libaom (>= 1.0.1)
-  - SDWebImage (5.1.0):
-    - SDWebImage/Core (= 5.1.0)
-  - SDWebImage/Core (5.1.0)
-  - SDWebImageAVIFCoder (0.2.1):
-    - libavif (~> 0.2.0)
+  - libavif/libdav1d (0.3.0):
+    - libavif/libaom
+    - libdav1d (>= 0.4.0)
+  - libdav1d (0.4.0)
+  - SDWebImage (5.2.2):
+    - SDWebImage/Core (= 5.2.2)
+  - SDWebImage/Core (5.2.2)
+  - SDWebImageAVIFCoder (0.3.0):
+    - libavif (~> 0.3.0)
     - SDWebImage (~> 5.0)
 
 DEPENDENCIES:
+  - libavif/libaom
+  - libavif/libdav1d
   - SDWebImageAVIFCoder (from `../`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - libaom
     - libavif
+    - libdav1d
     - SDWebImage
 
 EXTERNAL SOURCES:
@@ -24,10 +33,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   libaom: 1e48c68559b8d6191c1a9f266e0bee83b2dd21fd
-  libavif: 251b8a20baa5b05467cc64c3b844eaa7b5cf3a62
-  SDWebImage: fb387001955223213dde14bc08c8b73f371f8d8f
-  SDWebImageAVIFCoder: 0cc05dc868739b68d6b61856ef11e1aea6af68eb
+  libavif: 8ae7eca52a4ba56592c63991a30697a9a24244e7
+  libdav1d: 097f791c93d050b1cb6c0788fbe6c9024ceb3d7e
+  SDWebImage: 5fcdb02cc35e05fc35791ec514b191d27189f872
+  SDWebImageAVIFCoder: f994b0bf9e8748a837bd18ec8491228690c16612
 
-PODFILE CHECKSUM: cb60778bff8fb5ce4fbc8792f6079317b7a897be
+PODFILE CHECKSUM: 1daaa635bd369cbbf21bf2dd090f9adae3a762dc
 
 COCOAPODS: 1.7.5

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ AVIF image spec is still in evolve. And the current upstream AVIF codec is a sim
 
 Since we rely on the external codec libavif. We may periodically update the dependency and bump version. Make sure you're using the latest version as possible as you can :)
 
+## aom && dav1d
+
+libavif is a still image codec. But AVIF is based on the AV1 Video standard. So it need a AV1 codec for support. This relationship is just like HEIF(image) and HEVC(video) codec.
+
+By default, libavif is built with [aom](https://aomedia.googlesource.com/aom/) codec support. aom is the first AV1 codec during the standard draft implementation.
+
+[dav1d](https://github.com/videolan/dav1d) is the new and next generation AV1 codec, focused on speed and correctness.
+
+From v0.3.0, libavif can built with dav1d. For CocoaPods user, you can simply use the subspec for this. Carthage for optional dav1d codec is not supported currently.
+
 ## Requirements
 
 + iOS 8
@@ -35,6 +45,13 @@ it, simply add the following line to your Podfile:
 
 ```ruby
 pod 'SDWebImageAVIFCoder'
+```
+
+Note: From version 0.4.0, if you want to use dav1d instead aom for libavif which we dependency on, control the subspec of libavif as well:
+
+```ruby
+pod 'SDWebImageAVIFCoder'
+pod 'libavif/libdav1d'
 ```
 
 Note: From version 0.2.0, the dependency libavif and libaom use the portable C implementation to works on Apple platforms. If you need the pre-built library with SIMD/AVX and assembly optimization, try the 0.1.0 version. 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ it, simply add the following line to your Podfile:
 pod 'SDWebImageAVIFCoder'
 ```
 
-Note: From version 0.4.0, if you want to use dav1d instead aom for libavif which we dependency on, control the subspec of libavif as well:
+Note: From version 0.4.0, if you want to use dav1d instead aom for libavif which we dependent on, control the subspec of libavif instead:
 
 ```ruby
 pod 'SDWebImageAVIFCoder'

--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -36,5 +36,5 @@ Which is built based on the open-sourced libavif codec.
   s.source_files = 'SDWebImageAVIFCoder/Classes/**/*', 'SDWebImageAVIFCoder/Module/SDWebImageAVIFCoder.h'
   
   s.dependency 'SDWebImage', '~> 5.0'
-  s.dependency 'libavif', '~> 0.2.0'
+  s.dependency 'libavif', '~> 0.3.0'
 end

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -278,11 +278,12 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     if (options[SDImageCoderEncodeCompressionQuality]) {
         compressionQuality = [options[SDImageCoderEncodeCompressionQuality] doubleValue];
     }
-    int rescaledQuality = AVIF_WORST_QUALITY - (int)((compressionQuality) * AVIF_WORST_QUALITY);
+    int rescaledQuality = AVIF_QUANTIZER_WORST_QUALITY - (int)((compressionQuality) * AVIF_QUANTIZER_WORST_QUALITY);
     
     avifRawData raw = AVIF_RAW_DATA_EMPTY;
     avifEncoder *encoder = avifEncoderCreate();
-    encoder->quality = rescaledQuality;
+    encoder->minQuantizer = rescaledQuality;
+    encoder->maxQuantizer = rescaledQuality;
     encoder->maxThreads = 2;
     avifResult result = avifEncoderWrite(encoder, avif, &raw);
     


### PR DESCRIPTION
See more about libavif changelog: https://github.com/AOMediaCodec/libavif/blob/master/CHANGELOG.md

Also update the API changes for libavif 0.3.0