### PR TITLE
Upgrade libavif to 0.3.11 support, last 0.3.x version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "SDWebImage/SDWebImage" ~> 5.0
-github "SDWebImage/libavif-Xcode" ~> 0.3.0
+github "SDWebImage/libavif-Xcode" ~> 0.3.11

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "SDWebImage/SDWebImage" "5.2.2"
 github "SDWebImage/libaom-Xcode" "1.0.1"
-github "SDWebImage/libavif-Xcode" "0.3.0"
+github "SDWebImage/libavif-Xcode" "0.3.11"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
   - libaom (1.0.1)
-  - libavif (0.3.0):
-    - libavif/libaom (= 0.3.0)
-  - libavif/libaom (0.3.0):
+  - libavif (0.3.11):
+    - libavif/libaom (= 0.3.11)
+  - libavif/libaom (0.3.11):
     - libaom (>= 1.0.1)
-  - libavif/libdav1d (0.3.0):
+  - libavif/libdav1d (0.3.11):
     - libavif/libaom
     - libdav1d (>= 0.4.0)
   - libdav1d (0.4.0)
   - SDWebImage (5.2.2):
     - SDWebImage/Core (= 5.2.2)
   - SDWebImage/Core (5.2.2)
-  - SDWebImageAVIFCoder (0.3.0):
+  - SDWebImageAVIFCoder (0.4.0):
     - libavif (~> 0.3.0)
     - SDWebImage (~> 5.0)
 
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   libaom: 1e48c68559b8d6191c1a9f266e0bee83b2dd21fd
-  libavif: 8ae7eca52a4ba56592c63991a30697a9a24244e7
+  libavif: 4d85bde998223e29aef651c10c41eff945cc679c
   libdav1d: 097f791c93d050b1cb6c0788fbe6c9024ceb3d7e
   SDWebImage: 5fcdb02cc35e05fc35791ec514b191d27189f872
-  SDWebImageAVIFCoder: f994b0bf9e8748a837bd18ec8491228690c16612
+  SDWebImageAVIFCoder: 022341960adbdc1394dae46d6e48331568234166
 
 PODFILE CHECKSUM: 1daaa635bd369cbbf21bf2dd090f9adae3a762dc
 

--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -36,5 +36,5 @@ Which is built based on the open-sourced libavif codec.
   s.source_files = 'SDWebImageAVIFCoder/Classes/**/*', 'SDWebImageAVIFCoder/Module/SDWebImageAVIFCoder.h'
   
   s.dependency 'SDWebImage', '~> 5.0'
-  s.dependency 'libavif', '~> 0.3.0'
+  s.dependency 'libavif', '~> 0.3.11'
 end

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -123,7 +123,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
 
 - (nullable CGImageRef)sd_createAVIFImageWithData:(nonnull NSData *)data CF_RETURNS_RETAINED {
     // Decode it
-    avifRawData rawData = {
+    avifROData rawData = {
         .data = (uint8_t *)data.bytes,
         .size = data.length
     };
@@ -280,7 +280,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     }
     int rescaledQuality = AVIF_QUANTIZER_WORST_QUALITY - (int)((compressionQuality) * AVIF_QUANTIZER_WORST_QUALITY);
     
-    avifRawData raw = AVIF_RAW_DATA_EMPTY;
+    avifRWData raw = AVIF_DATA_EMPTY;
     avifEncoder *encoder = avifEncoderCreate();
     encoder->minQuantizer = rescaledQuality;
     encoder->maxQuantizer = rescaledQuality;


### PR DESCRIPTION
Seems on 0.3.9 they break the public API, we need a fixup :(

https://github.com/AOMediaCodec/libavif/blob/master/CHANGELOG.md