### PR TITLE
Upgrade libavif to 0.4.0 support

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "SDWebImage/SDWebImage" ~> 5.0
-github "SDWebImage/libavif-Xcode" ~> 0.3.11
+github "SDWebImage/libavif-Xcode" ~> 0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "SDWebImage/SDWebImage" "5.2.2"
 github "SDWebImage/libaom-Xcode" "1.0.1"
-github "SDWebImage/libavif-Xcode" "0.3.11"
+github "SDWebImage/libavif-Xcode" "0.4.0"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
   - libaom (1.0.1)
-  - libavif (0.3.11):
-    - libavif/libaom (= 0.3.11)
-  - libavif/libaom (0.3.11):
+  - libavif (0.4.0):
+    - libavif/libaom (= 0.4.0)
+  - libavif/libaom (0.4.0):
     - libaom (>= 1.0.1)
-  - libavif/libdav1d (0.3.11):
+  - libavif/libdav1d (0.4.0):
     - libavif/libaom
     - libdav1d (>= 0.4.0)
   - libdav1d (0.4.0)
   - SDWebImage (5.2.2):
     - SDWebImage/Core (= 5.2.2)
   - SDWebImage/Core (5.2.2)
-  - SDWebImageAVIFCoder (0.4.0):
-    - libavif (~> 0.3.0)
+  - SDWebImageAVIFCoder (0.4.1):
+    - libavif (~> 0.4)
     - SDWebImage (~> 5.0)
 
 DEPENDENCIES:
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   libaom: 1e48c68559b8d6191c1a9f266e0bee83b2dd21fd
-  libavif: 4d85bde998223e29aef651c10c41eff945cc679c
+  libavif: 7f8a939f1773291bbafbd2a0fa08d7cacd014553
   libdav1d: 097f791c93d050b1cb6c0788fbe6c9024ceb3d7e
   SDWebImage: 5fcdb02cc35e05fc35791ec514b191d27189f872
-  SDWebImageAVIFCoder: 022341960adbdc1394dae46d6e48331568234166
+  SDWebImageAVIFCoder: 8c71bf3d9405f556aea95432c0781786e61befe0
 
 PODFILE CHECKSUM: 1daaa635bd369cbbf21bf2dd090f9adae3a762dc
 

--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -36,5 +36,5 @@ Which is built based on the open-sourced libavif codec.
   s.source_files = 'SDWebImageAVIFCoder/Classes/**/*', 'SDWebImageAVIFCoder/Module/SDWebImageAVIFCoder.h'
   
   s.dependency 'SDWebImage', '~> 5.0'
-  s.dependency 'libavif', '~> 0.3.11'
+  s.dependency 'libavif', '~> 0.4'
 end


### PR DESCRIPTION
The 0.4.0 does not break the API we used, however, our Podspec and Cartfile limit the version to `~> 0.3.11`. make it un-compatible for 0.4.0

This PR fix it.