### PR TITLE
use vImage framework to accelerate conversion from YUV to RGB(A)

### DIFF
--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -408,10 +408,10 @@ static void ConvertAvifImagePlanar16ToRGB16U(avifImage * avif, uint8_t * outPixe
 
     vImage_YpCbCrToARGB convInfo = {0};
 
-    uint8_t* argbPixels = NULL;
-    uint8_t* dummyCb = NULL;
-    uint8_t* dummyCr = NULL;
-    uint8_t* dummyAlpha = NULL;
+    uint16_t* argbPixels = NULL;
+    uint16_t* dummyCb = NULL;
+    uint16_t* dummyCr = NULL;
+    uint16_t* dummyAlpha = NULL;
 
     if(!hasAlpha) {
         argbPixels = calloc(avif->width * avif->height * 4, sizeof(uint16_t));
@@ -421,7 +421,7 @@ static void ConvertAvifImagePlanar16ToRGB16U(avifImage * avif, uint8_t * outPixe
     }
 
     vImage_Buffer argbBuffer = {
-        .data = hasAlpha ? outPixels : argbPixels,
+        .data = hasAlpha ? outPixels : (uint8_t*)argbPixels,
         .width = avif->width,
         .height = avif->height,
         .rowBytes = avif->width * 4 * sizeof(uint16_t),

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -275,6 +275,9 @@ static void ConvertAvifImagePlanar8ToRGB8(avifImage * avif, uint8_t * outPixels)
                                                           kvImageARGB8888,
                                                           kvImageNoFlags);
             if(err != kvImageNoError) {
+                free(argbPixels);
+                free(dummyCb);
+                free(dummyCr);
                 NSLog(@"Failed to setup conversion: %ld", err);
                 return;
             }

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -5,6 +5,7 @@
 //  Created by lizhuoli on 2018/5/8.
 //
 
+#include <alloca.h>
 #import "SDImageAVIFCoder.h"
 #import <Accelerate/Accelerate.h>
 #if __has_include(<libavif/avif.h>)
@@ -13,38 +14,363 @@
 #import "avif.h"
 #endif
 
-// Convert 8/10/12bit AVIF image into RGBA8888
-static void ConvertAvifImagePlanarToRGB(avifImage * avif, uint8_t * outPixels) {
-    avifBool usesU16 = avifImageUsesU16(avif);
+// Convert 8bit AVIF image into RGB888/ARGB8888 using vImage Acceralation Framework.
+static void ConvertAvifImagePlanar8ToRGB8(avifImage * avif, uint8_t * outPixels) {
+    vImage_Error err = kvImageNoError;
     BOOL hasAlpha = avif->alphaPlane != NULL;
     size_t components = hasAlpha ? 4 : 3;
-    if (usesU16) {
-        float maxChannel = (float)((1 << avif->depth) - 1);
-        for (int j = 0; j < avif->height; ++j) {
-            for (int i = 0; i < avif->width; ++i) {
-                uint8_t * pixel = &outPixels[components * (i + (j * avif->width))];
-                uint16_t r = *((uint16_t *)&avif->rgbPlanes[AVIF_CHAN_R][(i * 2) + (j * avif->rgbRowBytes[AVIF_CHAN_R])]);
-                uint16_t g = *((uint16_t *)&avif->rgbPlanes[AVIF_CHAN_G][(i * 2) + (j * avif->rgbRowBytes[AVIF_CHAN_G])]);
-                uint16_t b = *((uint16_t *)&avif->rgbPlanes[AVIF_CHAN_B][(i * 2) + (j * avif->rgbRowBytes[AVIF_CHAN_B])]);
-                pixel[0] = (uint8_t)roundf((r / maxChannel) * 255.0f);
-                pixel[1] = (uint8_t)roundf((g / maxChannel) * 255.0f);
-                pixel[2] = (uint8_t)roundf((b / maxChannel) * 255.0f);
-                if (avif->alphaPlane) {
-                    uint16_t a = *((uint16_t *)&avif->alphaPlane[(i * 2) + (j * avif->alphaRowBytes)]);
-                    pixel[3] = (uint8_t)roundf((a / maxChannel) * 255.0f);
-                }
+    
+    uint8_t* intermediateBuffer = NULL;
+
+    if(!hasAlpha) {
+        intermediateBuffer = calloc(avif->width * avif->height * 4, sizeof(uint8_t));
+        if(!intermediateBuffer) {
+            return;
+        }
+    }
+
+    vImage_Buffer dstBuffer = {
+        .data = hasAlpha ? outPixels : intermediateBuffer,
+        .width = avif->width,
+        .height = avif->height,
+        .rowBytes = avif->width * 4,
+    };
+
+    avifReformatState state;
+    avifPrepareReformatState(avif, &state);
+
+    vImage_Buffer origY = {
+        .data = avif->yuvPlanes[AVIF_CHAN_Y],
+        .rowBytes = avif->yuvRowBytes[AVIF_CHAN_Y],
+        .width = avif->width,
+        .height = avif->height,
+    };
+
+    vImage_Buffer origCb = {
+        .data = avif->yuvPlanes[AVIF_CHAN_U],
+        .rowBytes = avif->yuvRowBytes[AVIF_CHAN_U],
+        .width = avif->width >> state.formatInfo.chromaShiftX,
+        .height = avif->height >> state.formatInfo.chromaShiftY,
+    };
+
+    if(!origCb.data) { // allocate dummy data to convert monochrome images.
+        origCb.data = alloca(origCb.width * sizeof(uint8_t));
+        origCb.rowBytes = 0;
+        memset(origCb.data, 128, origCb.width);
+    }
+    vImage_Buffer origCr = {
+        .data = avif->yuvPlanes[AVIF_CHAN_V],
+        .rowBytes = avif->yuvRowBytes[AVIF_CHAN_V],
+        .width = avif->width >> state.formatInfo.chromaShiftX,
+        .height = avif->height >> state.formatInfo.chromaShiftY,
+    };
+    if(!origCr.data) { // allocate dummy data to convert monochrome images.
+        origCr.data = alloca(origCr.width * sizeof(uint8_t));
+        origCr.rowBytes = 0;
+        memset(origCr.data, 128, origCr.width);
+    }
+        
+    vImage_YpCbCrToARGBMatrix matrix = {0};
+    matrix.Yp = 1.0f;
+    matrix.Cr_R = 2.0f * (1.0f - state.kr);
+    matrix.Cb_B = 2.0f * (1.0f - state.kb);
+    matrix.Cb_G = -2.0f * (1.0f - state.kr) * state.kr / state.kg;
+    matrix.Cr_G = -2.0f * (1.0f - state.kb) * state.kb / state.kg;
+    
+    vImage_YpCbCrPixelRange pixelRange = {0};
+    switch (avif->depth) {
+        case 8:
+            if (avif->yuvRange == AVIF_RANGE_LIMITED) {
+                pixelRange.Yp_bias = 16;
+                pixelRange.YpRangeMax = 235;
+                pixelRange.YpMax = 255;
+                pixelRange.YpMin = 0;
+                pixelRange.CbCr_bias = 128;
+                pixelRange.CbCrRangeMax = 240;
+                pixelRange.CbCrMax = 255;
+                pixelRange.CbCrMin = 0;
+            }else{
+                pixelRange.Yp_bias = 0;
+                pixelRange.YpRangeMax = 255;
+                pixelRange.YpMax = 255;
+                pixelRange.YpMin = 0;
+                pixelRange.CbCr_bias = 128;
+                pixelRange.CbCrRangeMax = 255;
+                pixelRange.CbCrMax = 255;
+                pixelRange.CbCrMin = 0;
             }
+            break;
+        /*
+        case 10: // FIXME(ledyba-z): Support acceleration also on 10bit images.
+            if (avif->yuvRange == AVIF_RANGE_LIMITED) {
+                pixelRange.Yp_bias = 64;
+                pixelRange.YpRangeMax = 940;
+                pixelRange.YpMax = 1023;
+                pixelRange.YpMin = 0;
+                pixelRange.CbCr_bias = 512;
+                pixelRange.CbCrRangeMax = 960;
+                pixelRange.CbCrMax = 1023;
+                pixelRange.CbCrMin = 0;
+            }else{
+                pixelRange.Yp_bias = 0;
+                pixelRange.YpRangeMax = 1023;
+                pixelRange.YpMax = 1023;
+                pixelRange.YpMin = 0;
+                pixelRange.CbCr_bias = 512;
+                pixelRange.CbCrRangeMax = 1023;
+                pixelRange.CbCrMax = 1023;
+                pixelRange.CbCrMin = 0;
+            }
+            break;
+        case 12: // FIXME(ledyba-z): Support acceleration also on 12bit images.
+            if (avif->yuvRange == AVIF_RANGE_LIMITED) {
+                pixelRange.Yp_bias = 256;
+                pixelRange.YpRangeMax = 3760;
+                pixelRange.YpMax = 4095;
+                pixelRange.YpMin = 0;
+                pixelRange.CbCr_bias = 2048;
+                pixelRange.CbCrRangeMax = 3840;
+                pixelRange.CbCrMax = 4095;
+                pixelRange.CbCrMin = 0;
+            }else{
+                pixelRange.Yp_bias = 0;
+                pixelRange.YpRangeMax = 4095;
+                pixelRange.YpMax = 4095;
+                pixelRange.YpMin = 0;
+                pixelRange.CbCr_bias = 2048;
+                pixelRange.CbCrRangeMax = 4095;
+                pixelRange.CbCrMax = 4095;
+                pixelRange.CbCrMin = 0;
+            }
+            break;
+        */
+        default:
+            free(intermediateBuffer);
+            NSLog(@"Unknown bit depth: %d", avif->depth);
+            return;
+    }
+    
+    vImage_YpCbCrToARGB convInfo = {0};
+    
+    uint8_t const permuteMap[4] = {0, 1, 2, 3};
+    switch(avif->yuvFormat) {
+        case AVIF_PIXEL_FORMAT_NONE:
+            free(intermediateBuffer);
+            NSLog(@"Invalid pixel format.");
+            return;
+        case AVIF_PIXEL_FORMAT_YUV420:
+        case AVIF_PIXEL_FORMAT_YV12:
+        {
+            err =
+            vImageConvert_YpCbCrToARGB_GenerateConversion(&matrix,
+                                                          &pixelRange,
+                                                          &convInfo,
+                                                          kvImage420Yp8_Cb8_Cr8,
+                                                          kvImageARGB8888,
+                                                          kvImageNoFlags);
+            if(err != kvImageNoError) {
+                free(intermediateBuffer);
+                NSLog(@"Failed to setup conversion: %ld", err);
+                return;
+            }
+                    
+            err = vImageConvert_420Yp8_Cb8_Cr8ToARGB8888(&origY,
+                                                         &origCb,
+                                                         &origCr,
+                                                         &dstBuffer,
+                                                         &convInfo,
+                                                         permuteMap,
+                                                         255,
+                                                         kvImageNoFlags);
+            if(err != kvImageNoError) {
+                free(intermediateBuffer);
+                NSLog(@"Failed to convert to ARGB8888: %ld", err);
+                return;
+            }
+            break;
+        }
+        case AVIF_PIXEL_FORMAT_YUV444:
+        {
+            err =
+            vImageConvert_YpCbCrToARGB_GenerateConversion(&matrix,
+                                                          &pixelRange,
+                                                          &convInfo,
+                                                          kvImage444CrYpCb8,
+                                                          kvImageARGB8888,
+                                                          kvImageNoFlags);
+            if(err != kvImageNoError) {
+                free(intermediateBuffer);
+                NSLog(@"Failed to setup conversion: %ld", err);
+                return;
+            }
+
+            vImage_Buffer tmpBuffer = {
+                .data = calloc(avif->width * avif->height * 3, sizeof(uint8_t)),
+                .width = avif->width,
+                .height = avif->height,
+                .rowBytes = avif->width * 3,
+            };
+            if(!tmpBuffer.data) {
+                free(intermediateBuffer);
+                return;
+            }
+            err = vImageConvert_Planar8toRGB888(&origCr, &origY, &origCb, &tmpBuffer, kvImageNoFlags);
+            if(err != kvImageNoError) {
+                NSLog(@"Failed to composite kvImage444CrYpCb8: %ld", err);
+                free(intermediateBuffer);
+                free(tmpBuffer.data);
+                return;
+            }
+            vImageConvert_444CrYpCb8ToARGB8888(&tmpBuffer,
+                                               &dstBuffer,
+                                               &convInfo,
+                                               permuteMap,
+                                               255,
+                                               kvImageNoFlags);
+            free(intermediateBuffer);
+            free(tmpBuffer.data);
+            if(err != kvImageNoError) {
+                NSLog(@"Failed to convert to ARGB8888: %ld", err);
+                return;
+            }
+            break;
+        }
+        case AVIF_PIXEL_FORMAT_YUV422:
+        {
+            err =
+            vImageConvert_YpCbCrToARGB_GenerateConversion(&matrix,
+                                                          &pixelRange,
+                                                          &convInfo,
+                                                          kvImage422YpCbYpCr8,
+                                                          kvImageARGB8888,
+                                                          kvImageNoFlags);
+            if(err != kvImageNoError) {
+                NSLog(@"Failed to setup conversion: %ld", err);
+                return;
+            }
+
+            vImage_Buffer tmpY1 = {
+                .data = calloc(avif->width/2 * avif->height, sizeof(uint8_t)),
+                .width = avif->width/2,
+                .height = avif->height,
+                .rowBytes = avif->width/2,
+            };
+            if(!tmpY1.data) {
+                free(intermediateBuffer);
+                return;
+            }
+            vImage_Buffer tmpY2 = {
+                .data = calloc(avif->width/2 * avif->height, sizeof(uint8_t)),
+                .width = avif->width/2,
+                .height = avif->height,
+                .rowBytes = avif->width/2,
+            };
+            if(!tmpY2.data) {
+                free(intermediateBuffer);
+                free(tmpY1.data);
+                return;
+            }
+            err= vImageConvert_ChunkyToPlanar8((const void*[]){origY.data, origY.data+1},
+                                               (const vImage_Buffer*[]){&tmpY1, &tmpY2},
+                                               2 /* channelCount */,2 /* src srcStrideBytes */,
+                                               avif->width/2, avif->height,
+                                               avif->width, kvImageNoFlags);
+            if(err != kvImageNoError) {
+                NSLog(@"Failed to separate Y channel: %ld", err);
+                free(intermediateBuffer);
+                free(tmpY1.data);
+                free(tmpY2.data);
+                return;
+            }
+            vImage_Buffer tmpBuffer = {
+                .data = calloc(avif->width * avif->height * 2, sizeof(uint8_t)),
+                .width = avif->width/2,
+                .height = avif->height,
+                .rowBytes = avif->width * 2,
+            };
+            if(!tmpBuffer.data) {
+                free(intermediateBuffer);
+                free(tmpY1.data);
+                free(tmpY2.data);
+                return;
+            }
+            err = vImageConvert_Planar8toARGB8888(&tmpY1, &origCb, &tmpY2, &origCr,
+                                                  &tmpBuffer, kvImageNoFlags);
+            if(err != kvImageNoError) {
+                NSLog(@"Failed to composite kvImage422YpCbYpCr8: %ld", err);
+                free(intermediateBuffer);
+                free(tmpY1.data);
+                free(tmpY2.data);
+                free(tmpBuffer.data);
+                return;
+            }
+            tmpBuffer.width *= 2;
+
+            err = vImageConvert_422YpCbYpCr8ToARGB8888(&tmpBuffer,
+                                                       &dstBuffer,
+                                                       &convInfo,
+                                                       permuteMap,
+                                                       255,
+                                                       kvImageNoFlags);
+            free(intermediateBuffer);
+            free(tmpY1.data);
+            free(tmpY2.data);
+            free(tmpBuffer.data);
+            if(err != kvImageNoError) {
+                NSLog(@"Failed to convert to ARGB8888: %ld", err);
+                return;
+            }
+            break;
+        }
+    }
+
+    if(hasAlpha) {
+        vImage_Buffer alpha = {
+            .data = avif->alphaPlane,
+            .width = avif->width,
+            .height = avif->height,
+            .rowBytes = avif->alphaRowBytes,
+        };
+        err = vImageOverwriteChannels_ARGB8888(&alpha, &dstBuffer, &dstBuffer, 0x8, kvImageNoFlags);
+        if(err != kvImageNoError) {
+            NSLog(@"Failed to overwrite alpha: %ld", err);
+            return;
         }
     } else {
-        for (int j = 0; j < avif->height; ++j) {
-            for (int i = 0; i < avif->width; ++i) {
-                uint8_t * pixel = &outPixels[components * (i + (j * avif->width))];
-                pixel[0] = avif->rgbPlanes[AVIF_CHAN_R][i + (j * avif->rgbRowBytes[AVIF_CHAN_R])];
-                pixel[1] = avif->rgbPlanes[AVIF_CHAN_G][i + (j * avif->rgbRowBytes[AVIF_CHAN_G])];
-                pixel[2] = avif->rgbPlanes[AVIF_CHAN_B][i + (j * avif->rgbRowBytes[AVIF_CHAN_B])];
-                if (avif->alphaPlane) {
-                    pixel[3] = avif->alphaPlane[i + (j * avif->alphaRowBytes)];
-                }
+        vImage_Buffer outBuffer = {
+            .data = outPixels,
+            .width = avif->width,
+            .height = avif->height,
+            .rowBytes = avif->width * components,
+        };
+        err = vImageConvert_ARGB8888toRGB888(&dstBuffer, &outBuffer, kvImageNoFlags);
+        free(intermediateBuffer);
+        if(err != kvImageNoError) {
+            NSLog(@"Failed to convert ARGB to RGB: %ld", err);
+            return;
+        }
+    }
+
+    
+}
+
+// Convert 10/12bit AVIF image into RGB888/ARGB8888
+static void ConvertAvifImagePlanar16ToRGB8(avifImage * avif, uint8_t * outPixels) {
+    BOOL hasAlpha = avif->alphaPlane != NULL;
+    size_t components = hasAlpha ? 4 : 3;
+    float maxChannel = (float)((1 << avif->depth) - 1);
+    for (int j = 0; j < avif->height; ++j) {
+        for (int i = 0; i < avif->width; ++i) {
+            uint8_t * pixel = &outPixels[components * (i + (j * avif->width))];
+            uint16_t r = *((uint16_t *)&avif->rgbPlanes[AVIF_CHAN_R][(i * 2) + (j * avif->rgbRowBytes[AVIF_CHAN_R])]);
+            uint16_t g = *((uint16_t *)&avif->rgbPlanes[AVIF_CHAN_G][(i * 2) + (j * avif->rgbRowBytes[AVIF_CHAN_G])]);
+            uint16_t b = *((uint16_t *)&avif->rgbPlanes[AVIF_CHAN_B][(i * 2) + (j * avif->rgbRowBytes[AVIF_CHAN_B])]);
+            pixel[0] = (uint8_t)roundf((r / maxChannel) * 255.0f);
+            pixel[1] = (uint8_t)roundf((g / maxChannel) * 255.0f);
+            pixel[2] = (uint8_t)roundf((b / maxChannel) * 255.0f);
+            if (hasAlpha) {
+                uint16_t a = *((uint16_t *)&avif->alphaPlane[(i * 2) + (j * avif->alphaRowBytes)]);
+                pixel[3] = (uint8_t)roundf((a / maxChannel) * 255.0f);
             }
         }
     }
@@ -136,9 +462,6 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         return nil;
     }
     
-    // use RGB instead of YUV
-    avifImageYUVToRGB(avif);
-    
     int width = avif->width;
     int height = avif->height;
     BOOL hasAlpha = avif->alphaPlane != NULL;
@@ -153,12 +476,17 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         avifImageDestroy(avif);
         return nil;
     }
-    // convert planar to RGB888/RGBA8888
-    ConvertAvifImagePlanarToRGB(avif, dest);
+    // convert planar to ARGB8888/RGB888
+    if(avifImageUsesU16(avif)) { // 10bit or 12bit (using normal CPU convert functions)
+        avifImageYUVToRGB(avif);
+        ConvertAvifImagePlanar16ToRGB8(avif, dest);
+    } else { //8bit (using vImage Acceralation Framework)
+        ConvertAvifImagePlanar8ToRGB8(avif, dest);
+    }
     
     CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, dest, rowBytes * height, FreeImageData);
     CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault;
-    bitmapInfo |= hasAlpha ? kCGImageAlphaPremultipliedLast : kCGImageAlphaNone;
+    bitmapInfo |= hasAlpha ? kCGImageAlphaPremultipliedFirst : kCGImageAlphaNone;
     CGColorSpaceRef colorSpaceRef = [SDImageCoderHelper colorSpaceGetDeviceRGB];
     CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
     CGImageRef imageRef = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, rowBytes, colorSpaceRef, bitmapInfo, provider, NULL, NO, renderingIntent);

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -484,6 +484,7 @@ static void ConvertAvifImagePlanar16ToRGB16U(avifImage * avif, uint8_t * outPixe
         err = vImageOverwriteChannelsWithScalar_Planar16U(pixelRange.CbCr_bias, &origCr, kvImageNoFlags);
         if (err != kvImageNoError) {
             free(argbPixels);
+            free(dummyCb);
             NSLog(@"Failed to fill dummy Cr buffer: %ld", err);
             return;
         }
@@ -543,6 +544,7 @@ static void ConvertAvifImagePlanar16ToRGB16U(avifImage * avif, uint8_t * outPixe
             free(dummyCb);
             free(dummyCr);
             free(dummyAlpha);
+            free(aYpCbCrBuffer.data);
             NSLog(@"Invalid pixel format.");
             return;
         case AVIF_PIXEL_FORMAT_YUV420:


### PR DESCRIPTION
Hi. I am working at Link-U, a company which publishes digital comics in Japan.

In this pull request, I added an optimized code path to speed up conversions from YUV to RGB(A) using [vImage framework](https://developer.apple.com/documentation/accelerate/conversion?language=objc).

Unfortunately, it seems that vImage conversion API does not provide fully support for 10bit/12bit YUV image. Hence, in this patch, conversions from only 8bit YUV images are accelerated.

## Benchmark result

All results are measured in iPhone 6, iOS 12.2.

### Original version

[Here](https://github.com/link-u/SDWebImageAVIFCoder/tree/wip/measure-original) is a branch with measuring code.

```
# 8-bit image
SDWebImageAVIFCoder_Example[765:156941] Converting from YUV to RGB takes 0.174398 sec
SDWebImageAVIFCoder_Example[765:156924] Static AVIF load success
# 10-bit image
SDWebImageAVIFCoder_Example[765:156941] Converting from YUV to RGB takes 0.465885 sec
SDWebImageAVIFCoder_Example[765:156924] HDR AVIF load success
```

### vImage version(this patch)

[Here](https://github.com/link-u/SDWebImageAVIFCoder/tree/wip/measure-vImage) is a branch with measuring code.

```
# 8-bit image
SDWebImageAVIFCoder_Example[768:157661] Converting from YUV to RGB takes 0.007166 sec
SDWebImageAVIFCoder_Example[768:157548] Static AVIF load success
# 10-bit image
SDWebImageAVIFCoder_Example[768:157661] Converting from YUV to RGB takes 0.460658 sec
SDWebImageAVIFCoder_Example[768:157548] HDR AVIF load success
 ```

This patch makes a conversion more than 24 times faster, in 8-bit image.

Please take a look!