### PR TITLE
Support libavif v0.60 and set proper color space as possible.

### DIFF
--- a/.github/workflows/check-image-decoding.yml
+++ b/.github/workflows/check-image-decoding.yml
@@ -34,6 +34,11 @@ jobs:
           file=$(basename ${file})
           "${CMD}" "${file}" "./decoded/${file}.png"
         done
+    - name: Upload result
+      uses: actions/upload-artifact@v1
+      with:
+        name: decoded-images
+        path: decoded
     - name: Install imagemagick to compare images.
       shell: bash
       run: brew install imagemagick

--- a/.github/workflows/check-image-decoding.yml
+++ b/.github/workflows/check-image-decoding.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: decoded-images
-        path: decoded
+        path: avif-sample-images/decoded
     - name: Install imagemagick to compare images.
       shell: bash
       run: brew install imagemagick

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "SDWebImage/SDWebImage" ~> 5.0
-github "SDWebImage/libavif-Xcode" ~> 0.5
+github "SDWebImage/libavif-Xcode" ~> 0.6

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.1.0"),
-        .package(url: "https://github.com/SDWebImage/libavif-Xcode.git", from: "0.5.0")
+        .package(url: "https://github.com/SDWebImage/libavif-Xcode.git", from: "0.6.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -36,5 +36,5 @@ Which is built based on the open-sourced libavif codec.
   s.source_files = 'SDWebImageAVIFCoder/Classes/**/*', 'SDWebImageAVIFCoder/Module/SDWebImageAVIFCoder.h'
   
   s.dependency 'SDWebImage', '~> 5.0'
-  s.dependency 'libavif', '~> 0.5'
+  s.dependency 'libavif', '~> 0.6'
 end

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -17,6 +17,196 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     free((void *)data);
 }
 
+static void CalcWhitePoint(uint16_t const colorPrimaries, vImageWhitePoint* const white) {
+    float primaries[8];
+    avifNclxColourPrimariesGetValues(colorPrimaries, primaries);
+    white->white_x = primaries[6];
+    white->white_y = primaries[7];
+}
+
+static void CalcRGBPrimaries(uint16_t const colorPrimaries, vImageRGBPrimaries* const prim) {
+    float primaries[8];
+    avifNclxColourPrimariesGetValues(colorPrimaries, primaries);
+    prim->red_x = primaries[0];
+    prim->red_y = primaries[1];
+    prim->green_x = primaries[2];
+    prim->green_y = primaries[3];
+    prim->blue_x = primaries[4];
+    prim->blue_y = primaries[5];
+    prim->white_x = primaries[6];
+    prim->white_y = primaries[7];
+}
+
+static void CalcTransferFunction(uint16_t const transferCharacteristics, vImageTransferFunction* const tf) {
+    // See: https://www.itu.int/rec/T-REC-H.273/en
+    static const float alpha = 1.099296826809442f;
+    static const float beta = 0.018053968510807f;
+    /*
+     // R' = c0 * pow( c1 * R + c2, gamma ) + c3,    (R >= cutoff)
+     // R' = c4 * R + c5                             (R < cutoff)
+    */
+
+    switch(transferCharacteristics) {
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_GAMMA28: // 5
+            tf->cutoff = -INFINITY;
+            tf->c0 = 1.0f;
+            tf->c1 = 1.0f;
+            tf->c2 = 0.0f;
+            tf->c3 = 0.0f;
+            tf->c4 = 0.0f;
+            tf->c5 = 0.0f;
+            tf->gamma = 1.0f/2.8f;
+            break;
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT709: // 1
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT601: // 6
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2020_10BIT: // 14
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2020_12BIT: // 15
+            tf->cutoff = beta;
+            //
+            tf->c0 = alpha;
+            tf->c1 = 1.0f;
+            tf->c2 = 0.0f;
+            tf->gamma = 0.45f;
+            tf->c3 = -(alpha - 1);
+            //
+            tf->c4 = 4.5f;
+            tf->c5 = 0.0f;
+            break;
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_ST240: // 7
+            tf->cutoff = beta;
+            //
+            tf->c0 = alpha;
+            tf->c1 = 1.0f;
+            tf->c2 = 0.0f;
+            tf->gamma = 0.45f;
+            tf->c3 = -(alpha - 1);
+            //
+            tf->c4 = 4.0f;
+            tf->c5 = 0.0f;
+            break;
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_LINEAR: // 8
+            tf->cutoff = INFINITY;
+            //
+            tf->c0 = 1.0f;
+            tf->c1 = 1.0f;
+            tf->c2 = 0.0f;
+            tf->gamma = 1.0f;
+            tf->c3 = 0.0f;
+            //
+            tf->c4 = 4.0f;
+            tf->c5 = 0.0f;
+            break;
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_IEC61966: // 11
+            tf->cutoff = beta;
+            //
+            tf->c0 = alpha;
+            tf->c1 = 1.0f;
+            tf->c2 = 0.0f;
+            tf->gamma = 0.45f;
+            tf->c3 = -(alpha - 1);
+            //
+            tf->c4 = 4.5f;
+            tf->c5 = 0.0f;
+            break;
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT1361_EXTENDED: // 12
+            tf->cutoff = beta;
+            //
+            tf->c0 = alpha;
+            tf->c1 = 1.0f;
+            tf->c2 = 0.0f;
+            tf->gamma = 0.45f;
+            tf->c3 = -(alpha - 1);
+            //
+            tf->c4 = 4.5f;
+            tf->c5 = 0.0f;
+            break;
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB: // 13
+            tf->cutoff = beta;
+            //
+            tf->c0 = alpha;
+            tf->c1 = 1.0f;
+            tf->c2 = 0.0f;
+            tf->gamma = 1.0f/2.4f;
+            tf->c3 = -(alpha - 1);
+            //
+            tf->c4 = 12.92f;
+            tf->c5 = 0.0f;
+            break;
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_ST428: // 17
+            tf->cutoff = -INFINITY;
+            //
+            tf->c0 = 1.0f;
+            tf->c1 = 48.0f / 52.37f;
+            tf->c2 = 0.0f;
+            tf->gamma = 1.0f/2.6f;
+            tf->c3 = 0.0f;
+            //
+            tf->c4 = 1.0f;
+            tf->c5 = 0.0f;
+            break;
+        // Can't be represented by vImageTransferFunction. Use gamma 2.2 as a fallback.
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_ST2084: // 16
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_HLG: // 18
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_LOG_100_1: // 9
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_LOG_100_SQRT: // 10
+        //
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_UNKNOWN: // 0
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_UNSPECIFIED: // 2
+        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_GAMMA22: // 4
+        default:
+            tf->cutoff = -INFINITY;
+            tf->c0 = 1.0f;
+            tf->c1 = 1.0f;
+            tf->c2 = 0.0f;
+            tf->c3 = 0.0f;
+            tf->c4 = 0.0f;
+            tf->c5 = 0.0f;
+            tf->gamma = 1.0f/2.2f;
+            break;
+    }
+}
+static CGColorSpaceRef CreateColorSpaceMono(uint16_t const colorPrimaries, uint16_t const transferCharacteristics) {
+    if (@available(macOS 10.10, iOS 8.0, tvOS 8.0, *)) {
+        vImage_Error err;
+        vImageWhitePoint white;
+        vImageTransferFunction transfer;
+        CalcWhitePoint(colorPrimaries, &white);
+        CalcTransferFunction(transferCharacteristics, &transfer);
+        CGColorSpaceRef colorSpace = vImageCreateMonochromeColorSpaceWithWhitePointAndTransferFunction(&white, &transfer, kCGRenderingIntentDefault, kvImagePrintDiagnosticsToConsole, &err);
+        if(err != kvImageNoError) {
+            NSLog(@"[BUG] Failed to create monochrome color space: %ld", err);
+            if(colorSpace != NULL) {
+                CGColorSpaceRelease(colorSpace);
+            }
+            return NULL;
+        }
+        return colorSpace;
+    }else{
+        return NULL;
+    }
+}
+
+static CGColorSpaceRef CreateColorSpaceRGB(uint16_t const colorPrimaries, uint16_t const transferCharacteristics) {
+    if (@available(macOS 10.10, iOS 8.0, tvOS 8.0, *)) {
+        vImage_Error err;
+        vImageRGBPrimaries primaries;
+        vImageTransferFunction transfer;
+        CalcRGBPrimaries(colorPrimaries, &primaries);
+        CalcTransferFunction(transferCharacteristics, &transfer);
+        CGColorSpaceRef colorSpace = vImageCreateRGBColorSpaceWithPrimariesAndTransferFunction(&primaries, &transfer, kCGRenderingIntentDefault, kvImagePrintDiagnosticsToConsole, &err);
+        if(err != kvImageNoError) {
+            NSLog(@"[BUG] Failed to create monochrome color space: %ld", err);
+            if(colorSpace != NULL) {
+                CGColorSpaceRelease(colorSpace);
+            }
+            return NULL;
+        }
+        return colorSpace;
+    }else{
+        return NULL;
+    }
+}
+
 static void CalcColorSpaceMono(avifImage * avif, CGColorSpaceRef* ref, BOOL* shouldRelease) {
     static CGColorSpaceRef defaultColorSpace;
     {
@@ -46,12 +236,81 @@ static void CalcColorSpaceMono(avifImage * avif, CGColorSpaceRef* ref, BOOL* sho
         *shouldRelease = FALSE;
         return;
     }
-    // TODO: (ledyba-z):
-    //  We can support other color spaces using
-    //      vImageCreateMonochromeColorSpaceWithWhitePointAndTransferFunction
-    // https://github.com/link-u/SDWebImageAVIFCoder/tree/feature/create-custom-colorspaces
-    *ref = defaultColorSpace;
-    *shouldRelease = FALSE;
+    uint16_t const colorPrimaries = avif->nclx.colourPrimaries;
+    uint16_t const transferCharacteristics = avif->nclx.transferCharacteristics;
+    if((colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_UNKNOWN ||
+        colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_UNSPECIFIED) &&
+       (transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_UNKNOWN ||
+        transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_UNSPECIFIED)) {
+        *ref = defaultColorSpace;
+        *shouldRelease = FALSE;
+        return;
+    }
+    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_SRGB &&
+       transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB) {
+        static CGColorSpaceRef sRGB = NULL;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            sRGB = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
+            if(sRGB == NULL) {
+                sRGB = defaultColorSpace;
+            }
+        });
+        *ref = sRGB;
+        *shouldRelease = FALSE;
+        return;
+    }
+    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_BT709 &&
+       transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT709) {
+        static CGColorSpaceRef bt709 = NULL;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            bt709 = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
+            if(bt709 == NULL) {
+                bt709 = defaultColorSpace;
+            }
+        });
+        *ref = bt709;
+        *shouldRelease = FALSE;
+        return;
+    }
+    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_BT2020 &&
+       (transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2020_10BIT ||
+        transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2020_12BIT)) {
+        static CGColorSpaceRef bt2020 = NULL;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            bt2020 = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
+            if(bt2020 == NULL) {
+                bt2020 = defaultColorSpace;
+            }
+        });
+        *ref = bt2020;
+        *shouldRelease = FALSE;
+        return;
+    }
+    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_P3 &&
+       transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB) {
+        static CGColorSpaceRef p3 = NULL;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            p3 = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
+            if(p3 == NULL) {
+                p3 = defaultColorSpace;
+            }
+        });
+        *ref = p3;
+        *shouldRelease = FALSE;
+        return;
+    }
+
+    *ref = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
+    if(*ref != NULL) {
+        *shouldRelease = TRUE;
+    } else {
+        *ref = defaultColorSpace;
+        *shouldRelease = FALSE;
+    }
 }
 
 static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shouldRelease) {
@@ -261,12 +520,13 @@ static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
         return;
     }
 
-    // TODO: (ledyba-z):
-    //  We can support other color spaces using
-    //      vImageCreateRGBColorSpaceWithPrimariesAndTransferFunction
-    // https://github.com/link-u/SDWebImageAVIFCoder/tree/feature/create-custom-colorspaces
-    *ref = defaultColorSpace;
-    *shouldRelease = FALSE;
+    *ref = CreateColorSpaceRGB(colorPrimaries, transferCharacteristics);
+    if(*ref != NULL) {
+        *shouldRelease = TRUE;
+    } else {
+        *ref = defaultColorSpace;
+        *shouldRelease = FALSE;
+    }
 }
 
 static CGImageRef CreateImageFromBuffer(avifImage * avif, vImage_Buffer* result) {

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -33,6 +33,7 @@ default_color_space:
 static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shouldRelease) {
     static CGColorSpaceRef defaultColorSpace = NULL;
     static CGColorSpaceRef sRGB = NULL;
+    static CGColorSpaceRef sRGBlinear = NULL;
     static CGColorSpaceRef bt709 = NULL;
     static CGColorSpaceRef bt2020 = NULL;
     static CGColorSpaceRef bt2020hlg = NULL;
@@ -63,6 +64,11 @@ static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
                 p3 = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3);
             } else {
                 p3 = defaultColorSpace;
+            }
+            if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, *)) {
+                sRGBlinear = CGColorSpaceCreateWithName(kCGColorSpaceLinearSRGB);
+            } else {
+                sRGBlinear = defaultColorSpace;
             }
             if (@available(macOS 10.14.3, iOS 12.3, tvOS 12.3, *)) {
                 p3linear = CGColorSpaceCreateWithName(kCGColorSpaceExtendedLinearDisplayP3);
@@ -108,6 +114,12 @@ static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
     if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_SRGB &&
        transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB) {
         *ref = sRGB;
+        *shouldRelease = FALSE;
+        return;
+    }
+    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_SRGB &&
+       transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_LINEAR) {
+        *ref = sRGBlinear;
         *shouldRelease = FALSE;
         return;
     }

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -38,13 +38,22 @@ static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
             defaultColorSpace = CGColorSpaceCreateDeviceRGB();
         });
     }
-
-    if((avif->profileFormat == AVIF_PROFILE_FORMAT_ICC) && avif->icc.data && avif->icc.size) {
-        if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, *)) {
-            *ref = CGColorSpaceCreateWithICCData(avif->icc.data);
-            *shouldRelease = TRUE;
-            return;
+    if(avif->profileFormat == AVIF_PROFILE_FORMAT_NONE) {
+        *ref = defaultColorSpace;
+        *shouldRelease = FALSE;
+        return;
+    }
+    if(avif->profileFormat == AVIF_PROFILE_FORMAT_ICC) {
+        if(avif->icc.data && avif->icc.size) {
+            if(@available(macOS 10.12, iOS 10.0, tvOS 10.0, *)) {
+                *ref = CGColorSpaceCreateWithICCData(avif->icc.data);
+                *shouldRelease = TRUE;
+                return;
+            }
         }
+        *ref = defaultColorSpace;
+        *shouldRelease = FALSE;
+        return;
     }
     uint16_t colorPrimaries = avif->nclx.colourPrimaries;
     uint16_t transferCharacteristics = avif->nclx.transferCharacteristics;

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -226,8 +226,8 @@ static void CalcColorSpaceMono(avifImage * avif, CGColorSpaceRef* ref, BOOL* sho
                 *ref = CGColorSpaceCreateWithICCData(avif->icc.data);
                 *shouldRelease = TRUE;
             }else{
-                CFDataRef iccData = CFDataCreateWithBytesNoCopy(NULL, avif->icc.data, avif->icc.size, NULL);
-                *ref = CGColorSpaceCreateWithICCProfile(iccData);
+                NSData* iccData = [NSData dataWithBytes:avif->icc.data length:avif->icc.size];
+                *ref = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)iccData);
                 *shouldRelease = TRUE;
             }
             return;
@@ -332,8 +332,8 @@ static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
                 *ref = CGColorSpaceCreateWithICCData(avif->icc.data);
                 *shouldRelease = TRUE;
             }else{
-                CFDataRef iccData = CFDataCreateWithBytesNoCopy(NULL, avif->icc.data, avif->icc.size, NULL);
-                *ref = CGColorSpaceCreateWithICCProfile(iccData);
+                NSData* iccData = [NSData dataWithBytes:avif->icc.data length:avif->icc.size];
+                *ref = CGColorSpaceCreateWithICCProfile((__bridge CFDataRef)iccData);
                 *shouldRelease = TRUE;
             }
             return;

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -30,7 +30,11 @@ static CGImageRef CreateImageFromBuffer(avifImage * avif, vImage_Buffer* result)
     //  use avif->nclx.colourPrimaries and avif->nclx.transferCharacteristics to detect appropriate color space.
     CGColorSpaceRef colorSpace = NULL;
     if(monochrome){
-        colorSpace = CGColorSpaceCreateDeviceGray();
+        vImage_Error err;
+        vImageWhitePoint whitePoint ;
+        vImageTransferFunction transferFunction;
+        CGColorRenderingIntent intent;
+        colorSpace = vImageCreateMonochromeColorSpaceWithWhitePointAndTransferFunction(&whitePoint, &transferFunction, intent, kvImageNoFlags, &err);
     }else{
         colorSpace = CGColorSpaceCreateDeviceRGB();
     }

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -38,17 +38,17 @@ static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{
             defaultColorSpace = CGColorSpaceCreateDeviceRGB();
-            if (@available(iOS 9.0, tvOS 9.0, *)) {
+            if (@available(macOS 10.5, iOS 9.0, tvOS 9.0, *)) {
                 sRGB = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
             } else {
                 sRGB = defaultColorSpace;
             }
-            if (@available(iOS 9.0, tvOS 9.0, *)) {
+            if (@available(macOS 10.11, iOS 9.0, tvOS 9.0, *)) {
                 bt709 = CGColorSpaceCreateWithName(kCGColorSpaceITUR_709);
             } else {
                 bt709 = defaultColorSpace;
             }
-            if (@available(iOS 9.0, tvOS 9.0, *)) {
+            if (@available(macOS 10.11, iOS 9.0, tvOS 9.0, *)) {
                 bt2020 = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020);
             } else {
                 bt2020 = defaultColorSpace;

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -225,8 +225,12 @@ static void CalcColorSpaceMono(avifImage * avif, CGColorSpaceRef* ref, BOOL* sho
             if(@available(macOS 10.12, iOS 10.0, tvOS 10.0, *)) {
                 *ref = CGColorSpaceCreateWithICCData(avif->icc.data);
                 *shouldRelease = TRUE;
-                return;
+            }else{
+                CFDataRef iccData = CFDataCreateWithBytesNoCopy(NULL, avif->icc.data, avif->icc.size, NULL);
+                *ref = CGColorSpaceCreateWithICCProfile(iccData);
+                *shouldRelease = TRUE;
             }
+            return;
         }
         *ref = defaultColorSpace;
         *shouldRelease = FALSE;
@@ -327,8 +331,12 @@ static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
             if(@available(macOS 10.12, iOS 10.0, tvOS 10.0, *)) {
                 *ref = CGColorSpaceCreateWithICCData(avif->icc.data);
                 *shouldRelease = TRUE;
-                return;
+            }else{
+                CFDataRef iccData = CFDataCreateWithBytesNoCopy(NULL, avif->icc.data, avif->icc.size, NULL);
+                *ref = CGColorSpaceCreateWithICCProfile(iccData);
+                *shouldRelease = TRUE;
             }
+            return;
         }
         *ref = defaultColorSpace;
         *shouldRelease = FALSE;

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -17,196 +17,6 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     free((void *)data);
 }
 
-static void CalcWhitePoint(uint16_t const colorPrimaries, vImageWhitePoint* const white) {
-    float primaries[8];
-    avifNclxColourPrimariesGetValues(colorPrimaries, primaries);
-    white->white_x = primaries[6];
-    white->white_y = primaries[7];
-}
-
-static void CalcRGBPrimaries(uint16_t const colorPrimaries, vImageRGBPrimaries* const prim) {
-    float primaries[8];
-    avifNclxColourPrimariesGetValues(colorPrimaries, primaries);
-    prim->red_x = primaries[0];
-    prim->red_y = primaries[1];
-    prim->green_x = primaries[2];
-    prim->green_y = primaries[3];
-    prim->blue_x = primaries[4];
-    prim->blue_y = primaries[5];
-    prim->white_x = primaries[6];
-    prim->white_y = primaries[7];
-}
-
-static void CalcTransferFunction(uint16_t const transferCharacteristics, vImageTransferFunction* const tf) {
-    // See: https://www.itu.int/rec/T-REC-H.273/en
-    static const float alpha = 1.099296826809442f;
-    static const float beta = 0.018053968510807f;
-    /*
-     // R' = c0 * pow( c1 * R + c2, gamma ) + c3,    (R >= cutoff)
-     // R' = c4 * R + c5                             (R < cutoff)
-    */
-
-    switch(transferCharacteristics) {
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_GAMMA28: // 5
-            tf->cutoff = -INFINITY;
-            tf->c0 = 1.0f;
-            tf->c1 = 1.0f;
-            tf->c2 = 0.0f;
-            tf->c3 = 0.0f;
-            tf->c4 = 0.0f;
-            tf->c5 = 0.0f;
-            tf->gamma = 1.0f/2.8f;
-            break;
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT709: // 1
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT601: // 6
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2020_10BIT: // 14
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2020_12BIT: // 15
-            tf->cutoff = beta;
-            //
-            tf->c0 = alpha;
-            tf->c1 = 1.0f;
-            tf->c2 = 0.0f;
-            tf->gamma = 0.45f;
-            tf->c3 = -(alpha - 1);
-            //
-            tf->c4 = 4.5f;
-            tf->c5 = 0.0f;
-            break;
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_ST240: // 7
-            tf->cutoff = beta;
-            //
-            tf->c0 = alpha;
-            tf->c1 = 1.0f;
-            tf->c2 = 0.0f;
-            tf->gamma = 0.45f;
-            tf->c3 = -(alpha - 1);
-            //
-            tf->c4 = 4.0f;
-            tf->c5 = 0.0f;
-            break;
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_LINEAR: // 8
-            tf->cutoff = INFINITY;
-            //
-            tf->c0 = 1.0f;
-            tf->c1 = 1.0f;
-            tf->c2 = 0.0f;
-            tf->gamma = 1.0f;
-            tf->c3 = 0.0f;
-            //
-            tf->c4 = 4.0f;
-            tf->c5 = 0.0f;
-            break;
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_IEC61966: // 11
-            tf->cutoff = beta;
-            //
-            tf->c0 = alpha;
-            tf->c1 = 1.0f;
-            tf->c2 = 0.0f;
-            tf->gamma = 0.45f;
-            tf->c3 = -(alpha - 1);
-            //
-            tf->c4 = 4.5f;
-            tf->c5 = 0.0f;
-            break;
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT1361_EXTENDED: // 12
-            tf->cutoff = beta;
-            //
-            tf->c0 = alpha;
-            tf->c1 = 1.0f;
-            tf->c2 = 0.0f;
-            tf->gamma = 0.45f;
-            tf->c3 = -(alpha - 1);
-            //
-            tf->c4 = 4.5f;
-            tf->c5 = 0.0f;
-            break;
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB: // 13
-            tf->cutoff = beta;
-            //
-            tf->c0 = alpha;
-            tf->c1 = 1.0f;
-            tf->c2 = 0.0f;
-            tf->gamma = 1.0f/2.4f;
-            tf->c3 = -(alpha - 1);
-            //
-            tf->c4 = 12.92f;
-            tf->c5 = 0.0f;
-            break;
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_ST428: // 17
-            tf->cutoff = -INFINITY;
-            //
-            tf->c0 = 1.0f;
-            tf->c1 = 48.0f / 52.37f;
-            tf->c2 = 0.0f;
-            tf->gamma = 1.0f/2.6f;
-            tf->c3 = 0.0f;
-            //
-            tf->c4 = 1.0f;
-            tf->c5 = 0.0f;
-            break;
-        // Can't be represented by vImageTransferFunction. Use gamma 2.2 as a fallback.
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_ST2084: // 16
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2100_HLG: // 18
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_LOG_100_1: // 9
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_LOG_100_SQRT: // 10
-        //
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_UNKNOWN: // 0
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_UNSPECIFIED: // 2
-        case AVIF_NCLX_TRANSFER_CHARACTERISTICS_GAMMA22: // 4
-        default:
-            tf->cutoff = -INFINITY;
-            tf->c0 = 1.0f;
-            tf->c1 = 1.0f;
-            tf->c2 = 0.0f;
-            tf->c3 = 0.0f;
-            tf->c4 = 0.0f;
-            tf->c5 = 0.0f;
-            tf->gamma = 1.0f/2.2f;
-            break;
-    }
-}
-static CGColorSpaceRef CreateColorSpaceMono(uint16_t const colorPrimaries, uint16_t const transferCharacteristics) {
-    if (@available(macOS 10.10, iOS 8.0, tvOS 8.0, *)) {
-        vImage_Error err;
-        vImageWhitePoint white;
-        vImageTransferFunction transfer;
-        CalcWhitePoint(colorPrimaries, &white);
-        CalcTransferFunction(transferCharacteristics, &transfer);
-        CGColorSpaceRef colorSpace = vImageCreateMonochromeColorSpaceWithWhitePointAndTransferFunction(&white, &transfer, kCGRenderingIntentDefault, kvImagePrintDiagnosticsToConsole, &err);
-        if(err != kvImageNoError) {
-            NSLog(@"[BUG] Failed to create monochrome color space: %ld", err);
-            if(colorSpace != NULL) {
-                CGColorSpaceRelease(colorSpace);
-            }
-            return NULL;
-        }
-        return colorSpace;
-    }else{
-        return NULL;
-    }
-}
-
-static CGColorSpaceRef CreateColorSpaceRGB(uint16_t const colorPrimaries, uint16_t const transferCharacteristics) {
-    if (@available(macOS 10.10, iOS 8.0, tvOS 8.0, *)) {
-        vImage_Error err;
-        vImageRGBPrimaries primaries;
-        vImageTransferFunction transfer;
-        CalcRGBPrimaries(colorPrimaries, &primaries);
-        CalcTransferFunction(transferCharacteristics, &transfer);
-        CGColorSpaceRef colorSpace = vImageCreateRGBColorSpaceWithPrimariesAndTransferFunction(&primaries, &transfer, kCGRenderingIntentDefault, kvImagePrintDiagnosticsToConsole, &err);
-        if(err != kvImageNoError) {
-            NSLog(@"[BUG] Failed to create monochrome color space: %ld", err);
-            if(colorSpace != NULL) {
-                CGColorSpaceRelease(colorSpace);
-            }
-            return NULL;
-        }
-        return colorSpace;
-    }else{
-        return NULL;
-    }
-}
-
 static void CalcColorSpaceMono(avifImage * avif, CGColorSpaceRef* ref, BOOL* shouldRelease) {
     static CGColorSpaceRef defaultColorSpace;
     {
@@ -236,81 +46,12 @@ static void CalcColorSpaceMono(avifImage * avif, CGColorSpaceRef* ref, BOOL* sho
         *shouldRelease = FALSE;
         return;
     }
-    uint16_t const colorPrimaries = avif->nclx.colourPrimaries;
-    uint16_t const transferCharacteristics = avif->nclx.transferCharacteristics;
-    if((colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_UNKNOWN ||
-        colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_UNSPECIFIED) &&
-       (transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_UNKNOWN ||
-        transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_UNSPECIFIED)) {
-        *ref = defaultColorSpace;
-        *shouldRelease = FALSE;
-        return;
-    }
-    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_SRGB &&
-       transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB) {
-        static CGColorSpaceRef sRGB = NULL;
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            sRGB = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
-            if(sRGB == NULL) {
-                sRGB = defaultColorSpace;
-            }
-        });
-        *ref = sRGB;
-        *shouldRelease = FALSE;
-        return;
-    }
-    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_BT709 &&
-       transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT709) {
-        static CGColorSpaceRef bt709 = NULL;
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            bt709 = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
-            if(bt709 == NULL) {
-                bt709 = defaultColorSpace;
-            }
-        });
-        *ref = bt709;
-        *shouldRelease = FALSE;
-        return;
-    }
-    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_BT2020 &&
-       (transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2020_10BIT ||
-        transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_BT2020_12BIT)) {
-        static CGColorSpaceRef bt2020 = NULL;
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            bt2020 = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
-            if(bt2020 == NULL) {
-                bt2020 = defaultColorSpace;
-            }
-        });
-        *ref = bt2020;
-        *shouldRelease = FALSE;
-        return;
-    }
-    if(colorPrimaries == AVIF_NCLX_COLOUR_PRIMARIES_P3 &&
-       transferCharacteristics == AVIF_NCLX_TRANSFER_CHARACTERISTICS_SRGB) {
-        static CGColorSpaceRef p3 = NULL;
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            p3 = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
-            if(p3 == NULL) {
-                p3 = defaultColorSpace;
-            }
-        });
-        *ref = p3;
-        *shouldRelease = FALSE;
-        return;
-    }
-
-    *ref = CreateColorSpaceMono(colorPrimaries, transferCharacteristics);
-    if(*ref != NULL) {
-        *shouldRelease = TRUE;
-    } else {
-        *ref = defaultColorSpace;
-        *shouldRelease = FALSE;
-    }
+    // TODO: (ledyba-z):
+    //  We can support other color spaces using
+    //      vImageCreateMonochromeColorSpaceWithWhitePointAndTransferFunction
+    // https://github.com/link-u/SDWebImageAVIFCoder/tree/feature/create-custom-colorspaces
+    *ref = defaultColorSpace;
+    *shouldRelease = FALSE;
 }
 
 static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shouldRelease) {
@@ -520,13 +261,12 @@ static void CalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
         return;
     }
 
-    *ref = CreateColorSpaceRGB(colorPrimaries, transferCharacteristics);
-    if(*ref != NULL) {
-        *shouldRelease = TRUE;
-    } else {
-        *ref = defaultColorSpace;
-        *shouldRelease = FALSE;
-    }
+    // TODO: (ledyba-z):
+    //  We can support other color spaces using
+    //      vImageCreateRGBColorSpaceWithPrimariesAndTransferFunction
+    // https://github.com/link-u/SDWebImageAVIFCoder/tree/feature/create-custom-colorspaces
+    *ref = defaultColorSpace;
+    *shouldRelease = FALSE;
 }
 
 static CGImageRef CreateImageFromBuffer(avifImage * avif, vImage_Buffer* result) {


### PR DESCRIPTION
Hi.

In this PR, set proper color profile values to CGImage (if possible).

This PR and https://github.com/AOMediaCodec/libavif/pull/98 may resolve https://github.com/SDWebImage/SDWebImageAVIFCoder/issues/12 .

Please take a look!