### PR TITLE
Release/v0.5.3

### DIFF
--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SDWebImageAVIFCoder'
-  s.version          = '0.5.2'
+  s.version          = '0.5.3'
   s.summary          = 'A SDWebImage coder plugin to support AVIF(AV1 Image File Format) image'
 
 # This description is used to generate tags and improve search results.

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -752,9 +752,6 @@ static CGImageRef CreateImage8(avifImage * avif) {
         memset(origCr.data, pixelRange.CbCr_bias, origCr.width);
     }
     
-    //TODO: (ledyba-z) we have to scale alpha when libavif v0.6.0 comes.
-    //  https://github.com/AOMediaCodec/libavif/issues/91
-
     uint8_t const permuteMap[4] = {0, 1, 2, 3};
     switch(avif->yuvFormat) {
         case AVIF_PIXEL_FORMAT_NONE:


### PR DESCRIPTION
(Relates to #16 )

Hi, I bumped up the version to v0.5.3, and also, I prepared the release note below. Please use if it's okay:

# Release note

## Fix

- Forgot to scale alpha channel transparency from 10 bit or 12 bit to 16bit in HDR images ( #14 )

## Enhancement

- Supports libavif v0.6.0
   - Decoding images with alpha-channel becomes faster 13%~25% than before (#13 ).
- Output grayscale images as possible ( #11 )
  - It reduces up to 66% memory usage when decoding monochrome images.
- Support color management (#13)
   - ICC profile.
   - H.273 color information is supported (as possible).
   