### PR TITLE
Fix the encoding compatibility for CMYK image

### DIFF
--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -110,7 +110,8 @@
         .bitsPerComponent = (uint32_t)bitsPerComponent,
         .bitsPerPixel = (uint32_t)bitsPerPixel,
         .colorSpace = CGImageGetColorSpace(imageRef),
-        .bitmapInfo = bitmapInfo
+        .bitmapInfo = bitmapInfo,
+        .renderingIntent = CGImageGetRenderingIntent(imageRef)
     };
     vImage_CGImageFormat destFormat = {
         .bitsPerComponent = 8,


### PR DESCRIPTION
This is the same as https://github.com/SDWebImage/SDWebImageWebPCoder/pull/53