### PR TITLE
Support libavif 0.9.1

### DIFF
--- a/.github/workflows/check-image-decoding.yml
+++ b/.github/workflows/check-image-decoding.yml
@@ -32,11 +32,7 @@ jobs:
         CMD="../Example/CLI.xcarchive/Products/usr/local/bin/SDWebImageAVIFCoder_Example CLI"
         for file in $(find . -name \*.avif); do
           file=$(basename ${file})
-          if (echo ${file} | grep "\(monochrome\|crop\|rotate\|mirror\)"); then
-            # FIXME(ledyba-z): Check them.
-            echo "Ignore: ${file}"
-            continue
-          elif (echo ${file} | grep "profile"); then
+          if (echo ${file} | grep "profile"); then
             # FIXME(ledyba-z): https://github.com/SDWebImage/SDWebImageAVIFCoder/issues/21
             echo "Ignore: ${file}"
             continue
@@ -58,11 +54,7 @@ jobs:
         cd avif-sample-images
         for file in $(find . -name \*.avif); do
           file=$(basename ${file})
-          if (echo ${file} | grep "\(monochrome\|crop\|rotate\|mirror\)"); then
-            # FIXME(ledyba-z): Check them.
-            echo "Ignore: ${file}"
-            continue
-          elif (echo ${file} | grep "profile"); then
+          if (echo ${file} | grep "profile"); then
             # FIXME(ledyba-z): https://github.com/SDWebImage/SDWebImageAVIFCoder/issues/21
             echo "Ignore: ${file}"
             continue

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "SDWebImage/SDWebImage" ~> 5.10
-github "SDWebImage/libavif-Xcode" >= 0.8.2
+github "SDWebImage/libavif-Xcode" >= 0.9.1

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.10.0"),
-        .package(url: "https://github.com/SDWebImage/libavif-Xcode.git", from: "0.8.2")
+        .package(url: "https://github.com/SDWebImage/libavif-Xcode.git", from: "0.9.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -40,6 +40,6 @@ Which is built based on the open-sourced libavif codec.
   }
   
   s.dependency 'SDWebImage', '~> 5.10'
-  s.dependency 'libavif', '>= 0.8.2'
+  s.dependency 'libavif', '>= 0.9.1'
   s.libraries = 'c++'
 end

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -64,6 +64,8 @@
     // Decode it
     avifDecoder * decoder = avifDecoderCreate();
     avifDecoderSetIOMemory(decoder, data.bytes, data.length);
+    // Disable strict mode to keep some AVIF image compatible
+    decoder->strictFlags = AVIF_STRICT_DISABLED;
     avifResult decodeResult = avifDecoderParse(decoder);
     if (decodeResult != AVIF_RESULT_OK) {
         NSLog(@"Failed to decode image: %s", avifResultToString(decodeResult));


### PR DESCRIPTION
This PR bump the libavif to 0.9.1+.

Because we need the new API `decoder->strictFlags = AVIF_STRICT_DISABLED` to disable the strict mode, see: 

https://github.com/AOMediaCodec/libavif/blob/master/CHANGELOG.md#091---2021-05-19