### PR TITLE
Fix ICC profile, buffer and AVIF encoding memory leak

### DIFF
--- a/SDWebImageAVIFCoder/Classes/ColorSpace.m
+++ b/SDWebImageAVIFCoder/Classes/ColorSpace.m
@@ -215,7 +215,7 @@ void SDAVIFCalcColorSpaceMono(avifImage * avif, CGColorSpaceRef* ref, BOOL* shou
     }
     if(avif->icc.data && avif->icc.size) {
         if(@available(macOS 10.12, iOS 10.0, tvOS 10.0, *)) {
-            CFDataRef iccData = CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, avif->icc.data, avif->icc.size,kCFAllocatorNull);
+            CFDataRef iccData = CFDataCreate(kCFAllocatorDefault, avif->icc.data, avif->icc.size);
             *ref = CGColorSpaceCreateWithICCData(iccData);
             CFRelease(iccData);
             *shouldRelease = TRUE;
@@ -313,7 +313,7 @@ void SDAVIFCalcColorSpaceRGB(avifImage * avif, CGColorSpaceRef* ref, BOOL* shoul
     }
     if(avif->icc.data && avif->icc.size) {
         if(@available(macOS 10.12, iOS 10.0, tvOS 10.0, *)) {
-            CFDataRef iccData = CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, avif->icc.data, avif->icc.size,kCFAllocatorNull);
+            CFDataRef iccData = CFDataCreate(kCFAllocatorDefault, avif->icc.data, avif->icc.size);
             *ref = CGColorSpaceCreateWithICCData(iccData);
             CFRelease(iccData);
             *shouldRelease = TRUE;

--- a/SDWebImageAVIFCoder/Classes/Conversion.m
+++ b/SDWebImageAVIFCoder/Classes/Conversion.m
@@ -704,11 +704,11 @@ static CGImageRef CreateCGImage8(avifImage * avif) {
     }
 
 end_all:
-    free(resultBufferData);
-    free(argbBufferData);
-    free(dummyCbData);
-    free(dummyCrData);
-    free(scaledAlphaBufferData);
+    if (resultBufferData) free(resultBufferData);
+    if (argbBufferData) free(argbBufferData);
+    if (dummyCbData) free(dummyCbData);
+    if (dummyCrData) free(dummyCrData);
+    if (scaledAlphaBufferData) free(scaledAlphaBufferData);
     return result;
 }
 


### PR DESCRIPTION
This PR fix the 3 issues @wensbo reported

1. `CFDataCreateWithBytesNoCopy` for ICC Profile cause issue because of ColorSync cache system
2. `free` on null pointer in error handing cause crash
3. AVIF encoding cause memory leak of `avifImage`

![image](https://user-images.githubusercontent.com/6919743/184107703-145e2a61-1548-4a7e-a417-cfd35c0f5242.png)
