### PR TITLE
[bug]fix include internal

### DIFF
--- a/SDWebImageAVIFCoder/Classes/ColorSpace.m
+++ b/SDWebImageAVIFCoder/Classes/ColorSpace.m
@@ -7,7 +7,7 @@
 
 #import "SDImageAVIFCoder.h"
 #import <Accelerate/Accelerate.h>
-#if __has_include(<libavif/avif.h>)
+#if __has_include(<libavif/avif.h>) && __has_include(<libavif/internal.h>)
 #import <libavif/avif.h>
 #import <libavif/internal.h>
 #else

--- a/SDWebImageAVIFCoder/Classes/Conversion.m
+++ b/SDWebImageAVIFCoder/Classes/Conversion.m
@@ -7,7 +7,7 @@
 
 #import "SDImageAVIFCoder.h"
 #import <Accelerate/Accelerate.h>
-#if __has_include(<libavif/avif.h>)
+#if __has_include(<libavif/avif.h>) && __has_include(<libavif/internal.h>)
 #import <libavif/avif.h>
 #import <libavif/internal.h>
 #else

--- a/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
+++ b/SDWebImageAVIFCoder/Classes/SDImageAVIFCoder.m
@@ -9,7 +9,7 @@
 #import <Accelerate/Accelerate.h>
 #import <os/lock.h>
 #import <libkern/OSAtomic.h>
-#if __has_include(<libavif/avif.h>)
+#if __has_include(<libavif/avif.h>) && __has_include(<libavif/internal.h>)
 #import <libavif/avif.h>
 #import <libavif/internal.h>
 #else


### PR DESCRIPTION
I got the following error in the source code I put in with Cocoapods.
This fix solves it by adding a condition to the include statement.

```
'libavif/internal.h' file not found
1. Did not find header 'internal.h' in framework 'libavif' (loaded from '~/Library/Developer/Xcode/DerivedData/{app name}/Build/Products/Debug-iphonesimulator/libavif')
```

Xcode: 13.4.1
CocoaPods: 1.11.3