### PR TITLE
The dependency should be "libavif/core" instead of default subspecs

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,7 @@ install! 'cocoapods', :generate_multiple_pod_projects => true
 target 'SDWebImageAVIFCoder_Example' do
   platform :ios, '9.0'
   pod 'SDWebImageAVIFCoder', :path => '../'
-  pod 'libavif', :subspecs => ['libaom', 'libdav1d']
+  pod 'libavif', :subspecs => ['core', 'librav1e', 'libdav1d']
 
   target 'SDWebImageAVIFCoder_Tests' do
     inherit! :search_paths
@@ -13,11 +13,11 @@ end
 target 'SDWebImageAVIFCoder_Example macOS' do
   platform :osx, '10.11'
   pod 'SDWebImageAVIFCoder', :path => '../'
-  pod 'libavif', :subspecs => ['libaom', 'libdav1d']
+  pod 'libavif', :subspecs => ['core', 'librav1e', 'libdav1d']
 end
 
 target 'SDWebImageAVIFCoder_Example CLI' do
   platform :osx, '10.11'
   pod 'SDWebImageAVIFCoder', :path => '../'
-  pod 'libavif', :subspecs => ['libaom', 'libdav1d']
+  pod 'libavif', :subspecs => ['core', 'librav1e', 'libdav1d']
 end

--- a/SDWebImageAVIFCoder.podspec
+++ b/SDWebImageAVIFCoder.podspec
@@ -40,6 +40,6 @@ Which is built based on the open-sourced libavif codec.
   }
   
   s.dependency 'SDWebImage', '~> 5.10'
-  s.dependency 'libavif', '>= 0.11.0'
+  s.dependency 'libavif/core', '>= 0.11.0'
   s.libraries = 'c++'
 end


### PR DESCRIPTION
libavif podspec specify the default subspecs to `libaom`, so this will cause we can not disable the libaom :((

Or the default codec will be always reset to aom, even I use the following syntax in Podfile

```
pod 'libavif', :subspecs => ['core', 'librav1e', 'libdav1d']
```