### PR TITLE
Added the option for avifCodecChoice to control which codec (aom/dav1d/rav1e/svt-av1) to use

### DIFF
--- a/SDWebImageAVIFCoder/Classes/Public/SDImageAVIFCoder.h
+++ b/SDWebImageAVIFCoder/Classes/Public/SDImageAVIFCoder.h
@@ -13,6 +13,12 @@
 
 static const SDImageFormat SDImageFormatAVIF = 15; // AV1-codec based HEIF
 
+/// A `avifCodecChoice` enum which specify the custom codec for AVIF decoding, defaults to 0 (`AVIF_CODEC_CHOICE_AUTO`)
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderAVIFDecodeCodecChoice;
+
+/// A `avifCodecChoice` enum which specify the custom codec for AVIF encoding, defaults to 0 (`AVIF_CODEC_CHOICE_AUTO`)
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderAVIFEncodeCodecChoice;
+
 /// Supports AVIF static image and AVIFS animated image
 @interface SDImageAVIFCoder : NSObject <SDAnimatedImageCoder>
 


### PR DESCRIPTION
This use the `SDImageCoderAVIFDecodeCodecChoice` and `SDImageCoderAVIFEncodeCodecChoice` to pass through the libavif API