### PR TITLE
Fix the wrong calculation of buffer of AVIF image which cause memory peak

### DIFF
--- a/SDWebImageAVIFCoder/Classes/Conversion.m
+++ b/SDWebImageAVIFCoder/Classes/Conversion.m
@@ -186,7 +186,7 @@ static CGImageRef CreateCGImage8(avifImage * avif) {
 
     vImage_YpCbCrToARGB convInfo = {0};
 
-    resultBufferData = calloc(components * rowBytes * avif->height, sizeof(uint8_t));
+    resultBufferData = calloc(rowBytes * avif->height, sizeof(uint8_t));
     if(resultBufferData == NULL) {
         goto end_all;
     }


### PR DESCRIPTION
This close #65 #63 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected buffer sizing in AVIF image processing to match actual per-row data, preventing over-allocation that could cause elevated memory usage or occasional crashes with certain images.

* **Performance**
  * Reduced memory footprint during AVIF decoding, improving efficiency and stability, especially on memory-constrained devices.
  * More consistent memory behavior when handling large or high-resolution AVIF images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->